### PR TITLE
[alert] update ListAlertResult to include paging info

### DIFF
--- a/alert/result.go
+++ b/alert/result.go
@@ -1,8 +1,9 @@
 package alert
 
 import (
-	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"time"
+
+	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 )
 
 type Alert struct {
@@ -37,7 +38,8 @@ type Integration struct {
 
 type ListAlertResult struct {
 	client.ResultMetadata
-	Alerts []Alert `json:"data"`
+	Alerts []Alert           `json:"data"`
+	Paging map[string]string `json:"paging,omitempty"`
 }
 
 type RequestStatusResult struct {


### PR DESCRIPTION
The List Alert response includes paging information, but the go SDK doesn't support.  Adding it:
https://docs.opsgenie.com/docs/alert-api#list-alerts